### PR TITLE
Adding IRATI syscalls in valgrind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.kdev4
 
 Makefile.in
+Makefile.vex.in
 Makefile
 .deps
 .libs

--- a/coregrind/m_syswrap/priv_syswrap-linux.h
+++ b/coregrind/m_syswrap/priv_syswrap-linux.h
@@ -357,6 +357,16 @@ DECL_TEMPLATE(linux, sys_getpeername);
 DECL_TEMPLATE(linux, sys_socketpair);
 DECL_TEMPLATE(linux, sys_kcmp);
 
+/* RINA specific calls */
+DECL_TEMPLATE(linux, sys_ipc_create);
+DECL_TEMPLATE(linux, sys_ipc_destroy);
+DECL_TEMPLATE(linux, sys_sdu_read);
+DECL_TEMPLATE(linux, sys_sdu_write);
+DECL_TEMPLATE(linux, sys_allocate_port);
+DECL_TEMPLATE(linux, sys_deallocate_port);
+DECL_TEMPLATE(linux, sys_management_sdu_read);
+DECL_TEMPLATE(linux, sys_management_sdu_write);
+
 #endif   // __PRIV_SYSWRAP_LINUX_H
 
 /*--------------------------------------------------------------------*/

--- a/coregrind/m_syswrap/syswrap-amd64-linux.c
+++ b/coregrind/m_syswrap/syswrap-amd64-linux.c
@@ -1071,7 +1071,7 @@ static SyscallTableEntry syscall_table[] = {
    LINX_(__NR_allocate_port,     sys_allocate_port),    // 321
    LINX_(__NR_deallocate_port,   sys_deallocate_port),  // 322
    LINXY(__NR_management_sdu_read,  sys_management_sdu_read),  // 323
-   LINX_(__NR_management_sdu_write, sys_management_sdu_write), // 324
+   LINX_(__NR_management_sdu_write, sys_management_sdu_write)  // 324
 };
 
 SyscallTableEntry* ML_(get_linux_syscall_entry) ( UInt sysno )

--- a/coregrind/m_syswrap/syswrap-amd64-linux.c
+++ b/coregrind/m_syswrap/syswrap-amd64-linux.c
@@ -1061,7 +1061,17 @@ static SyscallTableEntry syscall_table[] = {
 
    LINXY(__NR_process_vm_readv,  sys_process_vm_readv), // 310
    LINX_(__NR_process_vm_writev, sys_process_vm_writev),// 311
-   LINX_(__NR_kcmp,              sys_kcmp)              // 312
+   LINX_(__NR_kcmp,              sys_kcmp),             // 312
+
+   /* RINA specific system calls */
+   LINX_(__NR_ipc_create,        sys_ipc_create),       // 317
+   LINX_(__NR_ipc_destroy,       sys_ipc_destroy),      // 318
+   LINXY(__NR_sdu_read,          sys_sdu_read),         // 319
+   LINX_(__NR_sdu_write,         sys_sdu_write),        // 320
+   LINX_(__NR_allocate_port,     sys_allocate_port),    // 321
+   LINX_(__NR_deallocate_port,   sys_deallocate_port),  // 322
+   LINXY(__NR_management_sdu_read,  sys_management_sdu_read),  // 323
+   LINX_(__NR_management_sdu_write, sys_management_sdu_write), // 324
 };
 
 SyscallTableEntry* ML_(get_linux_syscall_entry) ( UInt sysno )

--- a/coregrind/m_syswrap/syswrap-linux.c
+++ b/coregrind/m_syswrap/syswrap-linux.c
@@ -10139,6 +10139,85 @@ PRE(sys_kcmp)
    }
 }
 
+
+/* ---------------------------------------------------------------------
+   RINA specific calls
+   ------------------------------------------------------------------ */
+
+/* IPCP management */
+PRE(sys_ipc_create)
+{
+   PRINT("sys_ipc_create ( %#lx, %#lx, %#lx, %#lx, %hd, %#lx )", ARG1, ARG2, ARG3, ARG4, (short)ARG5, ARG6);
+   PRE_REG_READ6(int, "ipc_create",
+                 const char*, process_name, const char *, process_instance, const char*, entity_name, const char*, entity_instance, vki_ipc_process_id_t, id, const char *, type);
+}
+
+PRE(sys_ipc_destroy)
+{
+   PRINT("sys_ipc_destroy ( %hd )", (short)ARG1);
+   PRE_REG_READ1(int, "ipc_destroy", vki_ipc_process_id_t, id);
+}
+
+/* Flow allocation calls */
+PRE(sys_allocate_port)
+{
+   PRINT("sys_allocate_port ( %hd, %#lx, %#lx )", (short)ARG1, ARG2, ARG3);
+   PRE_REG_READ3(int, "ipc_allocate_port", vki_ipc_process_id_t, id, const char *, process_name, const char *, process_instance);
+}
+
+PRE(sys_deallocate_port)
+{
+   PRINT("sys_deallocate_port ( %hd )", (short)ARG1);
+   PRE_REG_READ1(int, "ipc_deallocate_port", vki_ipc_process_id_t, id);
+}
+
+/* Normal SDUs */
+PRE(sys_sdu_read)
+{
+   PRINT("sys_sdu_read ( %ld, %#lx, %llu )", ARG1, ARG2, (ULong)ARG3);
+   PRE_REG_READ3(ssize_t, "sdu_read",
+                 unsigned int, id, char *, buf, vki_size_t, count);
+   PRE_MEM_WRITE( "sdu_read(buf)", ARG2, ARG3 );
+}
+
+POST(sys_sdu_read)
+{
+   vg_assert(SUCCESS);
+   POST_MEM_WRITE( ARG2, RES );
+}
+
+PRE(sys_sdu_write)
+{
+   PRINT("sys_sdu_write ( %ld, %#lx, %llu )", ARG1, ARG2, (ULong)ARG3);
+   PRE_REG_READ3(ssize_t, "sdu_write",
+                 unsigned int, id, const char *, buf, vki_size_t, count);
+   PRE_MEM_READ( "sdu_write(buf)", ARG2, ARG3 );
+}
+
+/* Mgmt SDUs */
+PRE(sys_management_sdu_read)
+{
+   PRINT("sys_management_sdu_read ( %ld, %#lx, %llu )", ARG1, ARG2,
+								(ULong)ARG3);
+   PRE_REG_READ3(ssize_t, "sdu_management_read",
+                 unsigned int, ipcp_id, char *, buf, vki_size_t, count);
+   PRE_MEM_WRITE( "sdu_management_read(buf)", ARG2, ARG3 );
+}
+
+POST(sys_management_sdu_read)
+{
+   vg_assert(SUCCESS);
+   POST_MEM_WRITE( ARG2, RES );
+}
+
+PRE(sys_management_sdu_write)
+{
+   PRINT("sys_management_sdu_write ( %ld, %#lx, %llu )", ARG1, ARG2, (ULong)ARG3);
+   PRE_REG_READ3(ssize_t, "management_sdu_write",
+                 unsigned int, ipcp_id, const char *, buf, vki_size_t, count);
+   PRE_MEM_READ( "management_sdu_write(buf)", ARG2, ARG3 );
+}
+
 #undef PRE
 #undef POST
 

--- a/coregrind/m_syswrap/syswrap-x86-linux.c
+++ b/coregrind/m_syswrap/syswrap-x86-linux.c
@@ -1813,7 +1813,7 @@ static SyscallTableEntry syscall_table[] = {
 //   LINX_(__NR_setns,             sys_ni_syscall),       // 346
    LINXY(__NR_process_vm_readv,  sys_process_vm_readv), // 347
    LINX_(__NR_process_vm_writev, sys_process_vm_writev),// 348
-   LINX_(__NR_kcmp,              sys_kcmp)              // 349
+   LINX_(__NR_kcmp,              sys_kcmp),             // 349
 
    /* RINA specific system calls */
    LINX_(__NR_ipc_create,        sys_ipc_create),       // 354
@@ -1823,7 +1823,7 @@ static SyscallTableEntry syscall_table[] = {
    LINX_(__NR_allocate_port,     sys_allocate_port),    // 358
    LINX_(__NR_deallocate_port,   sys_deallocate_port),  // 359
    LINXY(__NR_management_sdu_read,  sys_management_sdu_read),  // 360
-   LINX_(__NR_management_sdu_write, sys_management_sdu_write), // 361
+   LINX_(__NR_management_sdu_write, sys_management_sdu_write)  // 361
 };
 
 SyscallTableEntry* ML_(get_linux_syscall_entry) ( UInt sysno )

--- a/coregrind/m_syswrap/syswrap-x86-linux.c
+++ b/coregrind/m_syswrap/syswrap-x86-linux.c
@@ -1814,6 +1814,16 @@ static SyscallTableEntry syscall_table[] = {
    LINXY(__NR_process_vm_readv,  sys_process_vm_readv), // 347
    LINX_(__NR_process_vm_writev, sys_process_vm_writev),// 348
    LINX_(__NR_kcmp,              sys_kcmp)              // 349
+
+   /* RINA specific system calls */
+   LINX_(__NR_ipc_create,        sys_ipc_create),       // 354
+   LINX_(__NR_ipc_destroy,       sys_ipc_destroy),      // 355
+   LINXY(__NR_sdu_read,          sys_sdu_read),         // 356
+   LINX_(__NR_sdu_write,         sys_sdu_write),        // 357
+   LINX_(__NR_allocate_port,     sys_allocate_port),    // 358
+   LINX_(__NR_deallocate_port,   sys_deallocate_port),  // 359
+   LINXY(__NR_management_sdu_read,  sys_management_sdu_read),  // 360
+   LINX_(__NR_management_sdu_write, sys_management_sdu_write), // 361
 };
 
 SyscallTableEntry* ML_(get_linux_syscall_entry) ( UInt sysno )

--- a/include/vki/vki-linux.h
+++ b/include/vki/vki-linux.h
@@ -4515,6 +4515,11 @@ enum vki_kcmp_type {
    VKI_KCMP_TYPES
 };
 
+/* --- RINA specific types  --- */
+
+/* This is pretty use-less, why not use directly a short */
+typedef __vki_u16 vki_ipc_process_id_t;
+
 #endif // __VKI_LINUX_H
 
 /*--------------------------------------------------------------------*/

--- a/include/vki/vki-scnums-amd64-linux.h
+++ b/include/vki/vki-scnums-amd64-linux.h
@@ -395,6 +395,17 @@
 #define __NR_process_vm_writev  311
 #define __NR_kcmp               312
 
+/* RINA specific syscalls */
+#define __NR_ipc_create 317
+#define __NR_ipc_destroy 318
+#define __NR_sdu_read 319
+#define __NR_sdu_write 320
+#define __NR_allocate_port 321
+#define __NR_deallocate_port 322
+#define __NR_management_sdu_read 323
+#define __NR_management_sdu_write 324
+
+
 #endif /* __VKI_SCNUMS_AMD64_LINUX_H */
 
 /*--------------------------------------------------------------------*/

--- a/include/vki/vki-scnums-x86-linux.h
+++ b/include/vki/vki-scnums-x86-linux.h
@@ -385,6 +385,17 @@
 #define __NR_process_vm_writev  348
 #define __NR_kcmp               349
 
+/* RINA specific syscalls */
+#define __NR_ipc_create 354
+#define __NR_ipc_destroy 355
+#define __NR_sdu_read 356
+#define __NR_sdu_write 357
+#define __NR_allocate_port 358
+#define __NR_deallocate_port 359
+#define __NR_management_sdu_read 360
+#define __NR_management_sdu_write 361
+
+
 #endif /* __VKI_SCNUMS_X86_LINUX_H */
 
 /*--------------------------------------------------------------------*/


### PR DESCRIPTION
PRISTINE contribution:

Add the IRATI missing syscalls in valgrind, so that ipcm and management agent daemon can run in valgrind.
